### PR TITLE
suppress warnings when ignoring https

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,231 @@
-MIT License
 
-Copyright (c) 2017 InfraBox
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+APIs
+
+This project may include APIs to SAP or third party products or services. The use of these APIs, products and services may be subject to additional agreements. In no event shall the application of the Apache Software License, v.2 to this project grant any rights in or to these APIs, products or services that would alter, expand, be inconsistent with, or supersede any terms of these additional agreements. “API” means application programming interfaces, as well as their respective specifications and implementing code that allows other software products to communicate with or call on SAP or third party products or services (for example, SAP Enterprise Services, BAPIs, Idocs, RFCs and ABAP calls or other user exits) and may be made available through SAP or third party products, SDKs, documentation or other media.
+
+------------------------------------------------------------------------------
+SUBCOMPONENTS
+
+
+[****NOTE: Use this section to identify third party components or code snippets that are included in the project. This is for embedded components, not dependencies or prerequisites that must be obtained by users from third party sources outside of the project. If you have any questions please contact the Industry Standards and Open Source Team. Please delete this note prior to publication]
+
+This project includes the following subcomponents that are subject to separate license terms.
+Your use of these subcomponents is subject to the separate license terms applicable to
+each subcomponent.
+
+[****NOTE: List all third party components included in the project. Do not include the license text for these components here. License text should be included in the subsequent section. Please delete this note prior to publication]
+
+Component: [****name and versions]
+Licensor: [****licensor/author]
+Website: [****website]
+License: [****license]
+Additional Notices: [****Include any additional notices here. This can include owner or copyright year listed in MIT and BSD licenses, subcomponent notices listed at the end of the LICENSE file in Apache licensed components, notices contained in the NOTICE file in Apache licensed components, or other notices.]
+
+------------------------------------------------------------------------------
+
+[****Note: Use this section to include a single copy of each unique subcomponent license referenced in the previous section. For example, if there are three MIT licensed subcomponents then only publish the MIT license once. If there are Apache Software License subcomponents do not publish the Apache Software License in this section since it is already published above. Please delete this note prior to publication
+------------------------------------------------------------------------------
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # InfraBox CLI
-[![Build Status](https://infrabox.ninja/api/v1/projects/e2a803f3-55da-4683-8993-c3c6306d9a77/state.svg)](https://infrabox.ninja/dashboard/#/project/infrabox-cli)
-[![coverage](https://infrabox.ninja/api/v1/projects/e2a803f3-55da-4683-8993-c3c6306d9a77/badge.svg?subject=coverage&job_name=pyinfrabox)](https://infrabox.ninja/dashboard/#/project/infrabox-cli)
-[![Test Status](https://infrabox.ninja/api/v1/projects/e2a803f3-55da-4683-8993-c3c6306d9a77/tests.svg)](https://infrabox.ninja/dashboard/#/project/infrabox-cli)
+With the InfraBox CLI you can run your InfraBox jobs on you local machine and configure your project.
 
 ## Install
 To install infraboxcli you need to have these requirements already installed:
@@ -12,16 +10,16 @@ To install infraboxcli you need to have these requirements already installed:
 
 Then simply run:
 
-    $ pip install infraboxcli
+    pip install infraboxcli
 
 You can validate your installation by running:
 
-    $ infrabox version
+    infrabox version
 
 ## List Jobs
 If you have a more complex project it may be helpful to list all available jobs in it. For this you may use:
 
-    $ infrabox list
+    infrabox list
 
 It outputs the names of all available jobs. An example output may look like this:
 
@@ -63,9 +61,9 @@ In case you have multiple jobs defined an want to run only one of them you can d
     infrabox run <job-name>
 
 ## Push a Job
-To be able to use infrabox push you have to [create a project](https://infrabox.ninja/docs/#create-upload-project) in the InfraBox Dashboard and [create an auth token](https://infrabox.ninja/docs/#create-auth-token) for it.
+To be able to use infrabox push you have to create a project in the InfraBox Dashboard and create an auth token for it.
 
-Auth Token and InfraBox API Host must be set as environment variables. If you want to use the infrabox.ninja playground use `INFRABOX_URL=https://infrabox.ninja`.
+Auth Token and InfraBox API Host must be set as environment variables.
 
     export INFRABOX_CLI_TOKEN=<YOUR_ACCESS_TOKEN>
     export INFRABOX_URL=<INFRABOX_URL>
@@ -94,3 +92,12 @@ If you reference secrets in your job definition (i.e. as environment variable) t
         "SECRET_NAME1": "my secret value",
         "Another secret": "another value"
     }
+
+## How to get support
+If you need help please post your questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/infrabox).
+In case you found a bug please open a [Github Issue](https://github.com/InfraBox/infrabox/issues).
+Follow us on Twitter: [@Infra_Box](https://twitter.com/Infra_Box) or have look at our Slack channel [infrabox.slack.com](https://infrabox.slack.com/).
+
+## License
+Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
+This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE file](LICENSE).

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ It outputs the names of all available jobs. An example output may look like this
 ## Run a Job
 InfraBox CLI may be used to run you jobs on your local machine. It will also respect all the dependencies and run the jobs in the correct order. Available options are:
 
-	usage: infrabox run [-h] [--no-rm] [-t TAG] [--local-cache LOCAL_CACHE]
-						[job_name]
+    usage: infrabox run [-h] [--no-rm] [-t TAG] [--local-cache LOCAL_CACHE]
+                        [job_name]
 
-	positional arguments:
-	  job_name              Job name to execute
+    positional arguments:
+      job_name              Job name to execute
 
-	optional arguments:
-	  -h, --help            show this help message and exit
-	  --no-rm               Does not run 'docker-compose rm' before building
-	  -t TAG                Docker image tag
-	  --local-cache LOCAL_CACHE
-							Path to the local cache
+    optional arguments:
+      -h, --help            show this help message and exit
+      --no-rm               Does not run 'docker-compose rm' before building
+      -t TAG                Docker image tag
+      --local-cache LOCAL_CACHE
+                            Path to the local cache
 
 To run all jobs defined in your _infrabox.json_ file simply do:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # InfraBox CLI
-With the InfraBox CLI you can run your InfraBox jobs on you local machine and configure your project.
+With the InfraBox CLI you can run your InfraBox jobs on your local machine and configure your project.
 
 ## Install
 To install infraboxcli you need to have these requirements already installed:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you reference secrets in your job definition (i.e. as environment variable) t
 
 ## How to get support
 If you need help please post your questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/infrabox).
-In case you found a bug please open a [Github Issue](https://github.com/InfraBox/infrabox/issues).
+In case you found a bug please open a [Github Issue](https://github.com/SAP/InfraBox-cli/issues).
 Follow us on Twitter: [@Infra_Box](https://twitter.com/Infra_Box) or have look at our Slack channel [infrabox.slack.com](https://infrabox.slack.com/).
 
 ## License

--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -11,7 +11,7 @@ from infraboxcli.log import logger
 from infraboxcli.init import init
 from infraboxcli.pull import pull
 
-version = '0.6.5'
+version = '0.6.6'
 
 def main():
     username = 'unknown'

--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -115,6 +115,9 @@ def main():
     if args.ca_bundle:
         if args.ca_bundle.lower() == "false":
             args.ca_bundle = False
+            # according to: https://stackoverflow.com/a/28002687/131120
+            import requests.packages.urllib3 as urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         else:
             if not os.path.exists(args.ca_bundle):
                 logger.error("INFRABOX_CA_BUNDLE: %s not found" % args.ca_bundle)

--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -83,10 +83,10 @@ def main():
                             help="Job name to execute")
     parser_run.add_argument("--no-rm", action='store_true', required=False,
                             help="Does not run 'docker-compose rm' before building")
-    parser_run.add_argument("--build-arg", required=False, type=str, nargs='+',
-                            help="Set docker build arguments")
-    parser_run.add_argument("--env", required=False, type=str, nargs='+',
-                            help="Override environment variables")
+    parser_run.add_argument("--build-arg", required=False, type=str, nargs='?',
+                            help="Set docker build arguments", action='append')
+    parser_run.add_argument("--env", required=False, type=str, nargs='?',
+                            help="Override environment variables", action='append')
     parser_run.add_argument("--env-file", required=False, type=str, default=None,
                             help="Environment file to override environment values")
     parser_run.add_argument("-t", dest='tag', required=False, type=str,

--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -11,7 +11,7 @@ from infraboxcli.log import logger
 from infraboxcli.init import init
 from infraboxcli.pull import pull
 
-version = '0.6.7'
+version = '0.6.8'
 
 def main():
     username = 'unknown'

--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -11,7 +11,7 @@ from infraboxcli.log import logger
 from infraboxcli.init import init
 from infraboxcli.pull import pull
 
-version = '0.6.6'
+version = '0.6.7'
 
 def main():
     username = 'unknown'

--- a/pyinfrabox/infrabox/__init__.py
+++ b/pyinfrabox/infrabox/__init__.py
@@ -160,19 +160,6 @@ def parse_limits(d, path):
     if d['memory'] <= 255:
         raise ValidationError(path + ".memory", "must be greater than 255")
 
-def parse_kubernetes_limits(d, path):
-    check_allowed_properties(d, path, ("memory", "cpu"))
-    check_required_properties(d, path, ("memory", "cpu"))
-
-    check_number(d['cpu'], path + ".cpu")
-    check_number(d['memory'], path + ".memory")
-
-    if d['cpu'] <= 0:
-        raise ValidationError(path + ".cpu", "must be greater than 0")
-
-    if d['memory'] <= 255:
-        raise ValidationError(path + ".memory", "must be greater than 255")
-
 def parse_add_capabilities(d, path):
     check_string_array(d, path)
 
@@ -190,13 +177,6 @@ def parse_security_context(d, path):
 
     if 'privileged' in d:
         check_boolean(d['privileged'], path + ".privileged")
-
-def parse_service_spec(d, path):
-    if not isinstance(d, dict):
-        raise ValidationError(path, "must be an object")
-
-    for key, value in d.items():
-        check_text(value, path + "." + key)
 
 def parse_services(d, path):
     if not isinstance(d, list):
@@ -219,11 +199,8 @@ def parse_services(d, path):
 
         names.append(name)
 
-        if 'spec' in elem:
-            parse_service_spec(elem['spec'], p + ".spec")
-
 def parse_resources(d, path):
-    check_allowed_properties(d, path, ("limits", "kubernetes"))
+    check_allowed_properties(d, path, ("limits",))
     check_required_properties(d, path, ("limits",))
 
     parse_limits(d['limits'], path + ".limits")

--- a/pyinfrabox/infrabox/__init__.py
+++ b/pyinfrabox/infrabox/__init__.py
@@ -191,11 +191,36 @@ def parse_security_context(d, path):
     if 'privileged' in d:
         check_boolean(d['privileged'], path + ".privileged")
 
-def parse_resources_kubernetes(d, path):
-    check_allowed_properties(d, path, ('limits',))
-    check_required_properties(d, path, ("limits",))
+def parse_service_spec(d, path):
+    if not isinstance(d, dict):
+        raise ValidationError(path, "must be an object")
 
-    parse_kubernetes_limits(d['limits'], path + ".limits")
+    for key, value in d.items():
+        check_text(value, path + "." + key)
+
+def parse_services(d, path):
+    if not isinstance(d, list):
+        raise ValidationError(path, "must be an array")
+
+    names = []
+
+    for i in range(0, len(d)):
+        elem = d[i]
+        p = "%s[%s]" % (path, i)
+
+        check_allowed_properties(elem, p, ("apiVersion", "kind", "metadata", "spec"))
+        check_required_properties(elem, p, ("apiVersion", "kind", "metadata"))
+        check_required_properties(elem['metadata'], p + ".metadata", ("name", ))
+
+        name = elem['metadata']['name']
+
+        if name in names:
+            raise ValidationError(p, "duplicate service name found: %s" % name)
+
+        names.append(name)
+
+        if 'spec' in elem:
+            parse_service_spec(elem['spec'], p + ".spec")
 
 def parse_resources(d, path):
     check_allowed_properties(d, path, ("limits", "kubernetes"))
@@ -207,11 +232,14 @@ def parse_docker_image(d, path):
     check_allowed_properties(d, path, ("type", "name", "image", "depends_on", "resources",
                                        "environment", "timeout", "security_context",
                                        "build_context", "cache", "repository", "command",
-                                       "cluster", "registries"))
+                                       "cluster", "registries", "services"))
     check_required_properties(d, path, ("type", "name", "image", "resources"))
     check_name(d['name'], path + ".name")
     check_text(d['image'], path + ".image")
     parse_resources(d['resources'], path + ".resources")
+
+    if 'services' in d:
+        parse_services(d['services'], path + ".services")
 
     if 'cluster' in d:
         parse_cluster(d['cluster'], path + ".cluster")
@@ -247,11 +275,14 @@ def parse_docker(d, path):
     check_allowed_properties(d, path, ("type", "name", "docker_file", "depends_on", "resources",
                                        "build_only", "environment",
                                        "build_arguments", "deployments", "timeout", "security_context",
-                                       "build_context", "cache", "repository", "cluster"))
+                                       "build_context", "cache", "repository", "cluster", "services"))
     check_required_properties(d, path, ("type", "name", "docker_file", "resources"))
     check_name(d['name'], path + ".name")
     check_text(d['docker_file'], path + ".docker_file")
     parse_resources(d['resources'], path + ".resources")
+
+    if 'services' in d:
+        parse_services(d['services'], path + ".services")
 
     if 'cluster' in d:
         parse_cluster(d['cluster'], path + ".cluster")
@@ -361,6 +392,19 @@ def parse_deployment_ecr(d, path):
     if 'tag' in d:
         check_text(d['tag'], path + ".tag")
 
+def parse_deployment_gcr(d, path):
+    check_allowed_properties(d, path, ("type", "service_account", "repository", "host", "tag"))
+    check_required_properties(d, path, ("type", "service_account", "repository", "host"))
+
+    check_text(d['host'], path + ".host")
+    check_text(d['repository'], path + ".repository")
+
+    parse_secret_ref(d['service_account'], path + ".service_account")
+
+    if 'tag' in d:
+        check_text(d['tag'], path + ".tag")
+
+
 def parse_registries(e, path):
     if not isinstance(e, list):
         raise ValidationError(path, "must be an array")
@@ -405,6 +449,8 @@ def parse_deployments(e, path):
             parse_deployment_docker_registry(elem, p)
         elif t == 'ecr':
             parse_deployment_ecr(elem, p)
+        elif t == 'gcr':
+            parse_deployment_gcr(elem, p)
         else:
             raise ValidationError(p, "type '%s' not supported" % t)
 

--- a/pyinfrabox/utils.py
+++ b/pyinfrabox/utils.py
@@ -1,3 +1,5 @@
+import uuid
+
 from builtins import int, range, str
 from past.builtins import basestring
 
@@ -49,3 +51,11 @@ def check_number(d, path):
 def check_color(d, path):
     if d not in ("red", "green", "blue", "yellow", "orange", "white", "black", "grey"):
         raise ValidationError(path, "not a valid value")
+
+def validate_uuid4(uuid_string):
+    try:
+        val = uuid.UUID(uuid_string, version=4)
+    except ValueError:
+        return False
+
+    return val.hex == uuid_string.replace('-', '')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='infraboxcli',
-      version='0.6.7',
+      version='0.6.8',
       url='https://github.com/infrabox/cli',
       description='Command Line Interface for InfraBox',
       long_description=readme(),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='infraboxcli',
-      version='0.6.6',
+      version='0.6.7',
       url='https://github.com/infrabox/cli',
       description='Command Line Interface for InfraBox',
       long_description=readme(),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='infraboxcli',
-      version='0.6.5',
+      version='0.6.6',
       url='https://github.com/infrabox/cli',
       description='Command Line Interface for InfraBox',
       long_description=readme(),


### PR DESCRIPTION
Since it's sending 3 requests per second to the infrabox server, these warnings will make up the most part of a `infrabox push --show-console` output. This change removes the spam and lets the user bath in the glory of his insecure behaviour.